### PR TITLE
Use tostring(k) in error message.

### DIFF
--- a/enum.lua
+++ b/enum.lua
@@ -1,7 +1,7 @@
 local Enum = {}
 local Meta = {
-   __index    = function(_, k) error("Attempt to index non-existant enum '"..tostring(k).."'.") end,
-   __newindex = function()     error("Attempt to write to static enum") end,
+   __index    = function(_, k) error("Attempt to index non-existant enum '"..tostring(k).."'.", 2) end,
+   __newindex = function()     error("Attempt to write to static enum", 2) end,
 }
 
 function Enum.new(...)

--- a/enum.lua
+++ b/enum.lua
@@ -1,6 +1,6 @@
 local Enum = {}
 local Meta = {
-   __index    = function(_, k) error("Attempt to index non-existant enum '"..k.."'.") end,
+   __index    = function(_, k) error("Attempt to index non-existant enum '"..tostring(k).."'.") end,
    __newindex = function()     error("Attempt to write to static enum") end,
 }
 


### PR DESCRIPTION
Doing this leads to more clear error messages when you do something silly like:
```lua
local enum = Enum({'one', 'two'})
local someNilValue = nil
assert(enum[someNilValue])
```

> Attempt to index non-existant enum 'nil'

vs.

> attempt to concatenate local 'k' (a nil value)